### PR TITLE
Fix installation command bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ If you'd prefer to stay up-to-date with the bleeding edge, you can clone this re
 mkdir ~/Workspace
 cd ~/Workspace
 git clone https://github.com/facebook/origami.git
-mkdir -p "~/Library/Graphics/Quartz Composer Patches"
-ln -s origami/Origami.plugin "~/Library/Graphics/Quartz Composer Patches"
-ln -s origami/Origami "~/Library/Graphics/Quartz Composer Patches"
+mkdir -p ~/Library/Graphics/Quartz\ Composer\ Patches
+ln -s origami/Origami.plugin ~/Library/Graphics/Quartz\ Composer\ Patches
+ln -s origami/Origami ~/Library/Graphics/Quartz\ Composer\ Patches
 ```
 
 Feedback


### PR DESCRIPTION
This line in README.md produces wrong result.

```
mkdir -p "~/Library/Graphics/Quartz Composer Patches"
```

On MacOSX 10.9.1, this command creates a directory named "~" under current directory.
